### PR TITLE
Add a modified entrypoint, to allow init. scripts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,3 +84,5 @@ RUN printf '[Date]\ndate.timezone="%s"\n' $TZ > /usr/local/etc/php/conf.d/tzone.
 
 # Copy the modified entrypoint, to allow init. scripts.
 COPY docker-php-entrypoint /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/docker-php-entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,3 +81,6 @@ RUN apk add dpkg tzdata && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN printf '[Date]\ndate.timezone="%s"\n' $TZ > /usr/local/etc/php/conf.d/tzone.ini    
+
+# Copy the modified entrypoint, to allow init. scripts.
+COPY docker-php-entrypoint /usr/local/bin/

--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# This file is a modified entrypoint based upon the [original docker-php-entrypoint]
+# (https://github.com/docker-library/php/blob/master/8.3/alpine3.20/fpm/docker-php-entrypoint)
+
+# Start modification
+# Check for an `init.d` folder and execute the containg scripts.
+if [ -d /usr/local/bin/init.d ]; then
+	for f in /usr/local/bin/init.d/*.sh; do
+		ash "$f"
+	done
+fi
+# End modification
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+exec "$@"

--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -6,8 +6,8 @@ set -e
 
 # Start modification
 # Check for an `init.d` folder and execute the containg scripts.
-if [ -d /usr/local/bin/init.d ]; then
-	for f in /usr/local/bin/init.d/*.sh; do
+if [ -d /usr/local/bin/docker-entrypoint.d ]; then
+	for f in /usr/local/bin/docker-entrypoint.d/*.sh; do
 		ash "$f"
 	done
 fi


### PR DESCRIPTION
This PR will run any init. scripts that are in the folder: `/usr/local/bin/docker-entrypoint.d`.

It is similar to what the official nginx container does.

It will be used by the intranet-php-fpm container to run a `wp` script on container startup.