### PR TITLE
Update alpine version, keep perl, update tar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:22"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "chore"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build a Docker image
         run: docker build -t moj/wordpress-base-fpm .
 
@@ -47,20 +47,20 @@ jobs:
     steps:
       # First, checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # QEMU; multi-arch stuff
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       # get buildx - build multi-arch stuff
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # Access Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
       # Gather meta for the builds
       - name: Docker meta
         id: wordpress-base-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ministryofjustice/wordpress-base-fpm
           tags: |
@@ -81,7 +81,7 @@ jobs:
 
       # perform the builds
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN apk add --update bash  \
     imagemagick-dev \
     libjpeg-turbo \
     libgomp \
-    libtool \
-    automake \
     freetype-dev \
     icu-dev  \
     htop  \
@@ -27,7 +25,11 @@ RUN apk add --update bash  \
     perl \
     tar
 
-RUN apk add --no-cache --virtual .build-deps pcre-dev $PHPIZE_DEPS
+RUN apk add --no-cache --virtual .build-deps \
+    libtool \
+    automake \
+    pcre-dev \
+    $PHPIZE_DEPS
 
 RUN docker-php-ext-configure intl && \
     docker-php-ext-install -j "$(nproc)" exif gd zip mysqli opcache intl
@@ -68,7 +70,7 @@ RUN curl -fL -o optipng.tar.gz "https://sourceforge.net/projects/optipng/files/O
 RUN curl -fL -o libwebp.tar.gz "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP}.tar.gz"; \
     tar xvzf libwebp.tar.gz; ls -l; cd libwebp-${WEBP}/ && ./configure && make && make install
 
-RUN apk del .build-deps libtool automake $PHPIZE_DEPS
+RUN apk del .build-deps $PHPIZE_DEPS
 
 # Delete all contents of /tmp
 RUN rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-alpine3.21
+FROM php:8.3-fpm-alpine3.22
 
 # Remove CURL:
 # https://hub.docker.com/layers/ministryofjustice/wordpress-base-fpm/main/images/sha256-c9b578a559b7c1a217ccb5feeec3825f757a12a170083ad056b8039f22a8372c?context=repo&tab=vulnerabilities
@@ -23,7 +23,9 @@ RUN apk add --update bash  \
     icu-dev  \
     htop  \
     mariadb-client \
-    fcgi
+    fcgi \
+    perl \
+    tar
 
 RUN apk add --no-cache --virtual .build-deps pcre-dev $PHPIZE_DEPS
 


### PR DESCRIPTION
In this PR:

- Update alpine version (3.22 is maintained)
- Keep perl (it's removed in 3.22)
- Update tar (it has vulns)
- Update and pin GH actions
- Add Dependabot for GH actions.
